### PR TITLE
Prevent Mono push referencing SHA of previous release

### DIFF
--- a/core.py
+++ b/core.py
@@ -50,7 +50,7 @@ def context_from_env(args):
 # Version Bumping Logic
 def fetch_related_data(context):
     latest_release = fetch_latest_release_custom(context,context['input']['tag-prefix'])
-    context["sha"] = latest_release['target_commitish'] if latest_release is not None else getenv_or_throw("GITHUB_SHA")
+
     return {
         'related-prs': fetch_related_prs(context).body,
         'commit': fetch_commit(context).body,


### PR DESCRIPTION
Unclear why it would have done this